### PR TITLE
Add 'Quickstart' section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ This tool can be destructive and contain bugs, it will not let you overwrite the
  
  If a particular line in the input file is not supported by the parser, the tool will exit and print a link to submit an issue. If you are submitting an issue please attach a file that can reproduce the bug.
 
+## Quickstart
+
+After [installing go](https://golang.org/doc/install) (verify with `go version`, and don't forget the PATH steps), install and run this tool:
+
+```bash
+# Install
+go get github.com/jonnenauha/obj-simplify
+
+# Run
+obj-simplify -in <input-file> -out <output-file>
+
+# Help
+obj-simplify -h
+```
+
 ## Merging duplicate geometry
 
 Use `-eplison` to tune vector equality checks, the default is `1e-6`. This can have a positive impact especially on large OBJ files. Basic cleanup like trimming trailing zeros and converting -0 into 0 to reduce file size is also executed.


### PR DESCRIPTION
Figured things out from #2, but a quickstart section would be very helpful for those of us who are new to Go but want to optimize some models.

Thanks for making this! Just ran it through a bunch of models: ~70% average filesize reduction (they were messy models...); way fewer draw calls. About 4% of models failed or timed out, but I set a 10s timeout so that's on me. :)